### PR TITLE
Update python-grpcio-tools to match upstream python-grpcio

### DIFF
--- a/python-grpcio-tools/.SRCINFO
+++ b/python-grpcio-tools/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-grpcio-tools
 	pkgdesc = Python protobuf generator for GRPC
-	pkgver = 1.41.1
+	pkgver = 1.43.0
 	pkgrel = 1
 	url = https://grpc.io/
 	arch = x86_64
@@ -12,7 +12,7 @@ pkgbase = python-grpcio-tools
 	depends = python
 	depends = python-grpcio
 	depends = python-protobuf
-	source = https://files.pythonhosted.org/packages/source/g/grpcio-tools/grpcio-tools-1.41.1.tar.gz
-	sha512sums = 8f9ea6c2541670cb206059c378b33425fea3d63c3e890ba064581e780dcd3b0ce5f9c890731cac35d14281bfa49182857148fe2794a9373914493c4e0d4ce3b9
+	source = https://files.pythonhosted.org/packages/source/g/grpcio-tools/grpcio-tools-1.43.0.tar.gz
+	sha512sums = 60a5fa62fc1a81b5a57b47aca212ed94913ca20c3c1055dac18101776177fc0b18cc480c7356332e3eb4cf7819634ddc53d2e77f7c4b582a0fa53e26053f3ed4
 
 pkgname = python-grpcio-tools

--- a/python-grpcio-tools/PKGBUILD
+++ b/python-grpcio-tools/PKGBUILD
@@ -3,7 +3,7 @@
 # Bugreports can be filed at https://github.com/alexf91/AUR-PKGBUILDs
 
 pkgname='python-grpcio-tools'
-pkgver=1.41.1
+pkgver=1.43.0
 pkgrel=1
 pkgdesc="Python protobuf generator for GRPC"
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
@@ -16,7 +16,7 @@ noextract=()
 depends=('python' 'python-grpcio' 'python-protobuf')
 makedepends=('python-setuptools')
 source=("https://files.pythonhosted.org/packages/source/g/${_pkgname}/${_pkgname}-${pkgver}.tar.gz")
-sha512sums=('8f9ea6c2541670cb206059c378b33425fea3d63c3e890ba064581e780dcd3b0ce5f9c890731cac35d14281bfa49182857148fe2794a9373914493c4e0d4ce3b9')
+sha512sums=('60a5fa62fc1a81b5a57b47aca212ed94913ca20c3c1055dac18101776177fc0b18cc480c7356332e3eb4cf7819634ddc53d2e77f7c4b582a0fa53e26053f3ed4')
 
 build() {
   cd "$srcdir/$_pkgname-$pkgver"


### PR DESCRIPTION
[The Arch repos](https://archlinux.org/packages/?q=python-grpcio) have had `python-grpcio` at 1.43.x for a while now. This just bumps the version of `python-grpcio-tools` to match it.